### PR TITLE
Windows fixes

### DIFF
--- a/s3-sync/src/me/kanej/s3_sync/file_system.clj
+++ b/s3-sync/src/me/kanej/s3_sync/file_system.clj
@@ -1,5 +1,7 @@
 (ns me.kanej.s3-sync.file-system
-  (:require [pandect.core :as p]))
+  (:require [pandect.core :as p])
+  (:import [java.io File]
+           [java.util.regex Pattern]))
 
 (declare relative-path)
 (declare path->file-details)
@@ -29,8 +31,13 @@
 
 ;; Private Helper Functions
 
+(defn- root-path-regex [root]
+  (str "^" (Pattern/quote (str root File/separator))))
+
 (defn- relative-path [root target]
-  (.replaceAll target (str "^" root "/") ""))
+  (-> target
+    (.replaceAll (root-path-regex root) "")
+    (.replace File/separator "/")))
 
 (defn- path->file-details [root-path file]
   (let [absolute-path (.getAbsolutePath file)


### PR DESCRIPTION
I ran into two problems on Windows:

1. Trying to use the root path as a regex fails, because "C:\Users" looks like it uses the escape sequence \U.
1. If you get past that, all your files will get pushed to S3 with \ as the separator, rather than /. So, if you push a file located (relatively) at out\file.js, it will show up in the root folder of your S3 bucket with the name "out\file.js", instead of "file.js" in the "out" folder.

I think this fixes both of those problems, by quoting the root path before we do the regex replace, and then swapping all \ to / before returning the relative path. I tested by changing some files and running it twice: the first time it grabbed my files, and the second time it detected that nothing changed.

This might also fix issue #4, but I never ran into his second problem (with arity), so I'm not sure.

I haven't tested this on any Unix machines. Hopefully I didn't break that.