### PR TITLE
Added metadata to the S3 options

### DIFF
--- a/lein-s3-sync/project.clj
+++ b/lein-s3-sync/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-s3-sync "0.4.0"
+(defproject lein-s3-sync "0.4.0-SNAPSHOT"
   :description "Sync local folders to s3"
   :url "http://github.com/kanej/lein-s3-sync"
   :license {:name "Eclipse Public License"
@@ -6,7 +6,7 @@
   :scm {:name "git"
         :url "http://github.com/kanej/lein-s3-sync"
         :dir ".."}
-  :dependencies [[me.kanej/s3-sync "0.4.0"]]
+  :dependencies [[me.kanej/s3-sync "0.4.0-SNAPSHOT"]]
   :test-selectors {:default (complement :integration)
                    :integration :integration
                    :all (constantly true)}

--- a/lein-s3-sync/src/leiningen/s3_sync.clj
+++ b/lein-s3-sync/src/leiningen/s3_sync.clj
@@ -30,7 +30,7 @@
       (let [cred (select-keys config [:access-key :secret-key])
             dir-path (:local-dir config)
             bucket-name (:bucket config)
-            options (select-keys config [:public])]
+            options (select-keys config [:public :metadata])]
         (print (str "Syncing bucket " bucket-name " with directory " dir-path))
         (s3s/sync-to-s3 cred dir-path bucket-name options)
         (flush)))))

--- a/s3-sync/project.clj
+++ b/s3-sync/project.clj
@@ -1,4 +1,4 @@
-(defproject me.kanej/s3-sync "0.4.0"
+(defproject me.kanej/s3-sync "0.4.0-SNAPSHOT"
   :description "Library for syncing local folders to s3"
   :url "http://github.com/kanej/lein-s3-sync"
   :license {:name "Eclipse Public License"

--- a/s3-sync/src/me/kanej/s3_sync.clj
+++ b/s3-sync/src/me/kanej/s3_sync.clj
@@ -64,7 +64,8 @@
             aws-credentials
             bucket-name
             rel-path
-            (fs/combine-path local-dir rel-path))
+            (fs/combine-path local-dir rel-path)
+            (:metadata options))
 
           (when (:public options)
             (s3/make-file-public aws-credentials bucket-name rel-path))

--- a/s3-sync/src/me/kanej/s3_sync/s3.clj
+++ b/s3-sync/src/me/kanej/s3_sync/s3.clj
@@ -32,6 +32,6 @@
   (let [grant (s3/grant :all-users :read)]
     (s3/update-object-acl cred bucket-name key grant)))
 
-(defn put-file [cred bucket-name key file-path]
+(defn put-file [cred bucket-name key file-path metadata]
   (let [file (clojure.java.io/file file-path)]
-    (s3/put-object cred bucket-name key file)))
+    (s3/put-object cred bucket-name key file metadata)))


### PR DESCRIPTION
Takes care of https://github.com/kanej/lein-s3-sync/issues/7

I'm not sure how you wanted me to format this PR, I couldn't find any documentation on contributing guidelines.

Also I wasn't sure how to run the tests. But I did install this in my local maven repo, then uploaded an asset via
```clj
(let [cred        {:access-key (env :aws-key)
                   :secret-key (env :aws-secret)}
      dir-path    "resources/to-upload/"
      bucket-name (env :report-asset-bucket)
      options     {:public   true
                   :metadata {:cache-control "public, max-age=31536000"}}]
  (me.kanej.s3-sync/sync-to-s3 cred dir-path bucket-name options))
```

Then I verified that the cache control metadata was there with a GET request.

![screen shot 2017-09-15 at 5 05 10 pm](https://user-images.githubusercontent.com/2679997/30503675-2abccbd6-9a39-11e7-9472-f6426b494524.png)

So it appears to work. Please let me know if you'd like anything else.
