### PR TITLE
Add permissions to sync options

### DIFF
--- a/lein-s3-sync/project.clj
+++ b/lein-s3-sync/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-s3-sync "0.5.0"
+(defproject lein-s3-sync "0.5.1-SNAPSHOT"
   :description "Sync local folders to s3"
   :url "http://github.com/kanej/lein-s3-sync"
   :license {:name "Eclipse Public License"
@@ -6,7 +6,7 @@
   :scm {:name "git"
         :url "http://github.com/kanej/lein-s3-sync"
         :dir ".."}
-  :dependencies [[me.kanej/s3-sync "0.5.0"]]
+  :dependencies [[me.kanej/s3-sync "0.5.1-SNAPSHOT"]]
   :test-selectors {:default (complement :integration)
                    :integration :integration
                    :all (constantly true)}

--- a/s3-sync/project.clj
+++ b/s3-sync/project.clj
@@ -1,4 +1,4 @@
-(defproject me.kanej/s3-sync "0.5.0"
+(defproject me.kanej/s3-sync "0.5.1-SNAPSHOT"
   :description "Library for syncing local folders to s3"
   :url "http://github.com/kanej/lein-s3-sync"
   :license {:name "Eclipse Public License"

--- a/s3-sync/src/me/kanej/s3_sync.clj
+++ b/s3-sync/src/me/kanej/s3_sync.clj
@@ -65,7 +65,8 @@
             bucket-name
             rel-path
             (fs/combine-path local-dir rel-path)
-            (:metadata options))
+            (:metadata options)
+            (:permissions options))
 
           (when (:public options)
             (s3/make-file-public aws-credentials bucket-name rel-path))

--- a/s3-sync/src/me/kanej/s3_sync/s3.clj
+++ b/s3-sync/src/me/kanej/s3_sync/s3.clj
@@ -32,6 +32,6 @@
   (let [grant (s3/grant :all-users :read)]
     (s3/update-object-acl cred bucket-name key grant)))
 
-(defn put-file [cred bucket-name key file-path metadata]
+(defn put-file [cred bucket-name key file-path metadata permissions]
   (let [file (clojure.java.io/file file-path)]
-    (s3/put-object cred bucket-name key file metadata)))
+    (apply s3/put-object cred bucket-name key file metadata permissions)))


### PR DESCRIPTION
Issue: https://github.com/kanej/lein-s3-sync/issues/9

This allows public access (or other ACLs) to be set in the initial PUT request.

I tested this on dev and passed the permission `(s3/grant :all-users :read)` which worked. One thing to note though when you pass permissions during the initial `s3/put-object`, it only uses those permissions. The default permissions that would have been set are lost. 

E.G. Our default was that our account has `:full-control`, but setting it with `(s3/grant :all-users :read)` resulted in only that permission.

It doesn't matter much since we use IAM for authentication. 

Let me know if you want me to add comments or tests!