### PR TITLE
Change md5 dependency from pandect to clj-digest

### DIFF
--- a/s3-sync/project.clj
+++ b/s3-sync/project.clj
@@ -6,9 +6,9 @@
   :scm {:name "git"
         :url "http://github.com/kanej/lein-s3-sync"
         :dir ".."}
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [clj-aws-s3 "0.3.6"]
-                 [pandect "0.3.0"]]
+                 [digest "1.4.9"]]
   :profiles {:dev {:source-paths ["dev"]
                    :dependencies [[org.clojure/tools.namespace "0.2.3"]
                                   [org.clojure/java.classpath "0.2.0"]

--- a/s3-sync/src/me/kanej/s3_sync/file_system.clj
+++ b/s3-sync/src/me/kanej/s3_sync/file_system.clj
@@ -1,5 +1,6 @@
 (ns me.kanej.s3-sync.file-system
-  (:require [pandect.core :as p])
+  (:require [digest :as digest]
+            [clojure.java.io :as io])
   (:import [java.io File]
            [java.util.regex Pattern]))
 
@@ -43,6 +44,6 @@
 (defn- path->file-details [root-path file]
   (let [absolute-path (.getAbsolutePath file)
         rel-path (relative-path root-path absolute-path)
-        md5 (p/md5-file absolute-path)]
+        md5 (digest/md5 (io/as-file absolute-path))]
     {:path rel-path :md5 md5}))
 


### PR DESCRIPTION
pandect has some issue with latest version of Clojure. 

Since this project is only using md5, it is easier to use cli-digest library.

Here is one of the stacktrace when use pandect with latest Clojure. 

clojure.lang.Compiler$CompilerException: Syntax error macroexpanding clojure.core/ns at (pandect/gen/checksum.clj:1:1).
#:clojure.error{:phase :macro-syntax-check, :line 1, :column 1, :source "pandect/gen/checksum.clj", :symbol clojure.core/ns}
 at clojure.lang.Compiler.checkSpecs (Compiler.java:6971)
    clojure.lang.Compiler.macroexpand1 (Compiler.java:6987)
    clojure.lang.Compiler.macroexpand (Compiler.java:7074)
    clojure.lang.Compiler.eval (Compiler.java:7160)
    clojure.lang.Compiler.load (Compiler.java:7635)
    clojure.lang.RT.loadResourceScript (RT.java:381)
    clojure.lang.RT.loadResourceScript (RT.java:372)
    clojure.lang.RT.load (RT.java:463)
    clojure.lang.RT.load (RT.java:428)
    clojure.core$load$fn__6824.invoke (core.clj:6126)
    clojure.core$load.invokeStatic (core.clj:6125)
    clojure.core$load.doInvoke (core.clj:6109)
    clojure.lang.RestFn.invoke (RestFn.java:408)
    clojure.core$load_one.invokeStatic (core.clj:5908)
    clojure.core$load_one.invoke (core.clj:5903)
    clojure.core$load_lib$fn__6765.invoke (core.clj:5948)
    clojure.core$load_lib.invokeStatic (core.clj:5947)
    clojure.core$load_lib.doInvoke (core.clj:5928)
    clojure.lang.RestFn.applyTo (RestFn.java:142)
    clojure.core$apply.invokeStatic (core.clj:667)
    clojure.core$load_libs.invokeStatic (core.clj:5989)
    clojure.core$load_libs.doInvoke (core.clj:5969)
    clojure.lang.RestFn.applyTo (RestFn.java:137)
    clojure.core$apply.invokeStatic (core.clj:667)
    clojure.core$require.invokeStatic (core.clj:6007)
    clojure.core$require.doInvoke (core.clj:6007)
    clojure.lang.RestFn.invoke (RestFn.java:408)
    pandect.core$eval716$loading__6706__auto____717.invoke (core.clj:1)